### PR TITLE
BOLT #2: Make onion packet vary size.

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -601,7 +601,8 @@ is destined, is described in [BOLT #4](04-onion-routing.md).
    * [`8`:`amount_msat`]
    * [`32`:`payment_hash`]
    * [`4`:`cltv_expiry`]
-   * [`1366`:`onion_routing_packet`]
+   * [`2`:`len`]
+   * [`len`:`onion_routing_packet`]
 
 
 #### Requirements


### PR DESCRIPTION
My apology if I have missed the context of the 
conversation, but it seems for me that in order 
to smoothly update the sphinx onion packet version 
in the future we have to have onion packet size 
decoupled from the `update_add_htlc` message.